### PR TITLE
Add support for offset in archive.search

### DIFF
--- a/muninn/archive.py
+++ b/muninn/archive.py
@@ -1664,7 +1664,7 @@ class Archive(object):
         if self._storage is not None:
             return self._storage._root.replace('\\', '/')
 
-    def search(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[]):
+    def search(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[], offset=None):
         """Search the product catalogue for products matching the specified search expression.
 
         Arguments:
@@ -1683,11 +1683,12 @@ class Archive(object):
                         Properties are specified as `<namespace>.<identifier>`
                         (the namespace can be omitted for the `core` namespace).
                         If the `property_names` parameter is provided then the namespaces parameter is ignored.
+        offset      --  Offset the results by the specified number, useful for pagination.
 
         Returns:
         A list of matching products.
         """
-        return self._database.search(where, order_by, limit, parameters, namespaces, property_names)
+        return self._database.search(where, order_by, limit, parameters, namespaces, property_names, offset)
 
     def source_products(self, uuid):
         """Return the UUIDs of the products that are linked to the given product as source products.

--- a/muninn/database/postgresql.py
+++ b/muninn/database/postgresql.py
@@ -942,9 +942,9 @@ class PostgresqlBackend(DatabaseBackend):
         return sqls
 
     @translate_errors
-    def search(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[]):
+    def search(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[], offset=None):
         query, query_parameters, query_description = \
-            self._sql_builder.build_search_query(where, order_by, limit, parameters, namespaces, property_names)
+            self._sql_builder.build_search_query(where, order_by, limit, parameters, namespaces, property_names, offset)
 
         with self._connection:
             cursor = self._connection.cursor()

--- a/muninn/database/sql.py
+++ b/muninn/database/sql.py
@@ -575,7 +575,7 @@ class SQLBuilder(object):
 
         return query, where_parameters, result_fields
 
-    def build_search_query(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[]):
+    def build_search_query(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[], offset=None):
         if property_names:
             namespaces = []
             namespace_properties = {}
@@ -628,6 +628,19 @@ class SQLBuilder(object):
 
             limit_clause = "LIMIT %d" % limit
 
+        # Parse the offset clause.
+        offset_clause = ""
+        if offset is not None:
+            try:
+                offset = int(offset)
+            except (TypeError, ValueError):
+                raise Error("offset %r must be a positive integer" % offset)
+
+            if offset < 0:
+                raise Error("offset %r must be a positive integer" % offset)
+
+            offset_clause = "OFFSET %d" % offset
+
         # Generate the SELECT clause.
         select_list = []
         for namespace, identifiers in description:
@@ -649,6 +662,8 @@ class SQLBuilder(object):
             query = "%s %s" % (query, order_by_clause)
         if limit_clause:
             query = "%s %s" % (query, limit_clause)
+        if offset_clause:
+            query = "%s %s" % (query, offset_clause)
 
         return query, where_parameters, description
 

--- a/muninn/database/sqlite.py
+++ b/muninn/database/sqlite.py
@@ -885,9 +885,9 @@ class SQLiteBackend(DatabaseBackend):
         return sqls
 
     @translate_sqlite_errors
-    def search(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[]):
+    def search(self, where="", order_by=[], limit=None, parameters={}, namespaces=[], property_names=[], offset=None):
         query, query_parameters, query_description = \
-            self._sql_builder.build_search_query(where, order_by, limit, parameters, namespaces, property_names)
+            self._sql_builder.build_search_query(where, order_by, limit, parameters, namespaces, property_names, offset)
 
         with self._connection:
             cursor = self._connection.cursor()

--- a/test/test.py
+++ b/test/test.py
@@ -810,6 +810,15 @@ class TestArchive:
             s = archive.search(limit=x)
             assert len(s) == min(x, 2)
 
+        # offset
+        archive.ingest(['data/b.txt'])
+        s = archive.search(limit=1, order_by=['archive_date'], offset=0).pop()
+        assert s.core.physical_name == "pi.txt"
+        s = archive.search(limit=1, order_by=['archive_date'], offset=1).pop()
+        assert s.core.physical_name == "a.txt"
+        s = archive.search(limit=1, order_by=['archive_date'], offset=2).pop()
+        assert s.core.physical_name == "b.txt"
+
     def test_tags(self, archive):
         properties = self._ingest_file(archive)
         uuid = properties.core.uuid


### PR DESCRIPTION
Use-case is to support pagination. Tested this with `fs` and `postgresql,sqlite` in the test.cfg. Not sure if this is the best way to test this functionality; doing it this way depends on `order_by` functionality, but we need explicit ordering for offset to return the same results reliably.