### PR TITLE
Make access_key and secret_access_key not required

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -129,14 +129,14 @@ backend and may contain the following settings:
 - ``host``: Mandatory. S3 host name or URL.
 - ``port``: Optional. S3 host port.
 - ``region``: Optional. Name of the S3 region.
-- ``access_key``: Mandatory*. S3 authentication access key.
-- ``secret_access_key``: Mandatory*. S3 authentication secret access key.
+- ``access_key``: Optional*. S3 authentication access key.
+- ``secret_access_key``: Optional*. S3 authentication secret access key.
 - ``download_args``: [Optional] JSON representation of boto3 download_file ExtraArgs parameter.
 - ``upload_args``: [Optional] JSON representation of boto3 upload_file ExtraArgs parameter.
 - ``copy_args``: [Optional] JSON representation of boto3 copy ExtraArgs parameter.
 - ``transfer_config``: [Optional] JSON representation of boto3.s3.transfer.TransferConfig parameters.
 
-[*] ``access_key`` and ``secret_access_key`` can be taken from a credentials file pointed to by ``auth_file``. The entry in the credentials file should then have a key value equal to the ``host`` value in the archive configuration and it should contain fields for ``auth_type`` (set to ``S3``),  ``bucket`` (set equal to the ``bucket`` value in the archive configuration), and of course contain the ``access_key`` and ``secret_access_key`` fields.
+[*] ``access_key`` and ``secret_access_key`` can be taken from a credentials file pointed to by ``auth_file``. The entry in the credentials file should then have a key value equal to the ``host`` value in the archive configuration and it should contain fields for ``auth_type`` (set to ``S3``),  ``bucket`` (set equal to the ``bucket`` value in the archive configuration), and of course contain the ``access_key`` and ``secret_access_key`` fields. Otherwise boto3's standard credential resolving logic is used.
 
 # Section "swift"
 

--- a/muninn/storage/s3.py
+++ b/muninn/storage/s3.py
@@ -56,17 +56,12 @@ def create(configuration, tempdir, auth_file):
                     if option in record and option not in options:
                         options[option] = record[option]
 
-    # check that mandatory options are configured
-    for option in ('access_key', 'secret_access_key'):
-        if option not in options:
-            raise Error("'%s' not configured" % option)
-
     _S3Config.validate(options)
     return S3StorageBackend(tempdir=tempdir, **options)
 
 
 class S3StorageBackend(StorageBackend):  # TODO '/' in keys to indicate directory, 'dir/' with contents?
-    def __init__(self, bucket, host, access_key, secret_access_key, port=None, region=None, prefix='',
+    def __init__(self, bucket, host, access_key=None, secret_access_key=None, port=None, region=None, prefix='',
                  download_args=None, upload_args=None, copy_args=None, transfer_config=None, tempdir=None):
         super(S3StorageBackend, self).__init__(tempdir)
 


### PR DESCRIPTION
This it to facilitate boto3's credential resolving logic allowing usage of standard environmental variables and credential files. 

See: https://docs.aws.amazon.com/boto3/latest/guide/credentials.html#configuring-credentials

Tested with `storage = s3,swift`, `database = sqlite` and `remote_backends = file` in `test.cfg`.